### PR TITLE
Route dismission

### DIFF
--- a/docs/developers/ownership.md
+++ b/docs/developers/ownership.md
@@ -1,0 +1,9 @@
+# Ownership
+
+The ownership means that an object in the current game has an owner that control it. For a soldier, the ownership is the tower, but for routes and towers the ownership is the ruler
+
+It has to be already updated when something changes, when a soldier conquer a tower, it changes the ownership of the tower to the him owner.
+
+With it we can check whenever a soldier collide with another one if they are enemies or not and do things accordingly.
+
+At this time (alpha release), not every object has an ownership value.

--- a/docs/developers/unit_testing.md
+++ b/docs/developers/unit_testing.md
@@ -24,6 +24,8 @@ Use `--cov=rts` to measure the code coverage.
 
 Use `--cov-report term-missing:skip-covered --cov=rts` to report missing covered lines without showing full covered files.
 
+The complete command used by me in last development is `poetry run python -m pytest tests --cov=rts --cov-report term-missing:skip-covered`.
+
 Tests are executed remotely only for pull_requests. Runs them before commit and push changes. Pre commit hooks will be added to the project in near future.
 
 ### Unit testing on video/audio-less devices

--- a/rts/controllers/time_controller.py
+++ b/rts/controllers/time_controller.py
@@ -13,10 +13,9 @@ class TimeController(metaclass=MetaSingleton):
     """How many times update fps counter."""
 
     def __init__(self, ui_manager: pygame_gui.UIManager):
-        print(f"Visibility {get_fps_label_visibility()}")
         self.fps = 0
         fps_label_rel_rect = Rect(-20, -20, 100, 50)
-        fps_label_rel_rect.bottomright = (-30, -20)
+        fps_label_rel_rect.bottomright = (-60, -40)
         self.fps_label = pygame_gui.elements.UILabel(
             relative_rect=fps_label_rel_rect,
             text=str(""),
@@ -34,7 +33,7 @@ class TimeController(metaclass=MetaSingleton):
 
     def reset(self) -> None:
         self.clock_init = 0.0
-        self.clock_init_step = 0.0
+        self.clock_init_step = 1.0
         self.fps = 0
 
     def update(self, time_delta: int):
@@ -47,5 +46,6 @@ class TimeController(metaclass=MetaSingleton):
             print(fps_string)
             if self.fps_label is not None:
                 self.fps_label.set_text(fps_string)
+            return True
 
-        return self.clock_init
+        return False

--- a/rts/game.py
+++ b/rts/game.py
@@ -195,7 +195,7 @@ class Game:
                 if self.has_to_trace(event):
                     print(f"Tracing {self.tower_traced}")
                     self.tower_traced = self.start_trace()
-            
+
             if mouse_pressed[2]:
                 for route in self.routes:
                     if route.rect.collidepoint(mouse_pos):
@@ -271,7 +271,7 @@ class Game:
         )
 
         clock = pygame.time.Clock()
-        rts.controllers.time_controller.clock_init = 0.0
+        self.time_controller.clock_init = 0.0
         # Keeps looping until exit is required
         while self.running:
             # Calculate the current delta_time from last frame
@@ -284,30 +284,27 @@ class Game:
 
             # Events manager
             self.event_controller.handle_events(self.manager)
-            """
-        elif self.has_to_un_trace(event):
-          self.stop_trace()
-          self.tower_traced = None
-        elif self.has_to_trace(event):
-          self.tower_traced = self.start_trace()
-      """
 
             mouse_pos = mouse.get_pos()
 
+            # Rulers update
+            rulers = self.entity_controller.entities(Ruler)
+            rulers.update(delta=time_delta)
+            for ruler in rulers:
+                ruler.mouse_over(mouse_pos, self.screen)
+
             # Towers update
-            if self.entity_controller.has(Tower):
-                towers = self.entity_controller.entity_dict[Tower]
-                towers.update(delta=time_delta)
-                for tower in towers:
-                    self.screen.blit(tower.surf, tower.rect)
-                    pygame.draw.rect(
-                        self.screen,
-                        TEXT_COLOR,
-                        tower.s_gen_rect,
-                        border_radius=2,
-                    )
-                    tower.update_tooltip(mouse_pos, self.manager)
-                    tower.mouse_over(mouse_pos, self.screen)
+            towers = self.entity_controller.entities(Tower)
+            towers.update(delta=time_delta)
+            for tower in towers:
+                pygame.draw.rect(
+                    self.screen,
+                    TEXT_COLOR,
+                    tower.s_gen_rect,
+                    border_radius=2,
+                )
+                tower.update_tooltip(mouse_pos, self.manager)
+                tower.mouse_over(mouse_pos, self.screen)
 
             # Route updates
             if self.tower_traced is not None:
@@ -323,22 +320,17 @@ class Game:
                 route.over(mouse_pos, self.screen)
 
             # Soldiers updates
-            if Soldier in self.entity_controller.entity_dict.keys():
-                soldiers = self.entity_controller.entity_dict[Soldier]
-                soldiers.update(time_delta)
-                for soldier in soldiers:
-                    self.screen.blit(soldier.surf, soldier.rect)
-                    soldier.update_tooltip(mouse_pos, self.manager)
-
-            # Rulers update
-            if Ruler in self.entity_controller.entity_dict.keys():
-                rulers = self.entity_controller.entity_dict[Ruler]
-                rulers.update(delta=time_delta)
-                for ruler in rulers:
-                    self.screen.blit(ruler.surf, ruler.rect)
-                    ruler.mouse_over(mouse_pos, self.screen)
+            soldiers = self.entity_controller.entities(Soldier)
+            soldiers.update(time_delta)
+            for soldier in soldiers:
+                soldier.update_tooltip(mouse_pos, self.manager)
 
             # Renders the scene
+            entities = self.entity_controller.game_entities
+            for sprite in entities:
+                self.screen.blit(sprite.surf, sprite.rect)
+
+            # Render the Gui
             self.manager.update(time_delta)
             self.manager.draw_ui(self.screen)
             display.flip()

--- a/rts/game.py
+++ b/rts/game.py
@@ -1,5 +1,6 @@
 import math
 from random import randint
+from typing import List
 
 from pygame import K_DOWN, K_LEFT, K_RIGHT, K_UP, Rect, Surface
 from pygame import display, font, mouse, draw
@@ -39,7 +40,7 @@ class Game:
     running: bool
     """Define if the game has to go through the loop or exit it and stop his execution."""
 
-    routes: list[tuple[tuple[float, float], tuple[float, float]]]
+    routes: List[Route]
     tower_traced: Tower
 
     entity_controller: EntityController
@@ -194,6 +195,11 @@ class Game:
                 if self.has_to_trace(event):
                     print(f"Tracing {self.tower_traced}")
                     self.tower_traced = self.start_trace()
+            
+            if mouse_pressed[2]:
+                for route in self.routes:
+                    if route.rect.collidepoint(mouse_pos):
+                        self.routes.remove(route)
 
         def mouse_up(**args):
             event = args.get("event")
@@ -314,6 +320,7 @@ class Game:
             for route in self.routes:
                 # draw.line(self.screen, TEXT_COLOR, route[0], route[1], width=2)
                 route.update(time_delta, self.screen)
+                route.over(mouse_pos, self.screen)
 
             # Soldiers updates
             if Soldier in self.entity_controller.entity_dict.keys():

--- a/rts/models/game_entity.py
+++ b/rts/models/game_entity.py
@@ -11,6 +11,12 @@ class GameEntity(Sprite):
     color: tuple[int, int, int]
     size: tuple[float, float]
 
+    selected: bool
+    """
+    Gets or sets if the entity is selected or not.
+    You can select an entity by moving mouse over it or over the owner.
+    """
+
     # Constructor
     def __init__(
         self,
@@ -33,3 +39,5 @@ class GameEntity(Sprite):
         self.surf.fill(self.color)
         self.rect = self.surf.get_rect()
         self.rect.move_ip(self.x, self.y)
+
+        self.selected = False

--- a/rts/sprites/route.py
+++ b/rts/sprites/route.py
@@ -4,15 +4,17 @@ from pygame import Rect, Surface
 import pygame
 from rts.config import TEXT_COLOR
 from rts.controllers.entity_controller import EntityController
+from rts.models.game_entity import GameEntity
 from rts.sprites.soldier import Soldier
 from rts.sprites.tower import Tower
 
 
-class Route:
+class Route(GameEntity):
     start: Tower
     end: Tower
 
     def __init__(self, start: Tower, end: Tower) -> None:
+        super(Route, self).__init__(0, 0, [0, 0, 0], [0, 0])
         self.start = start
         self.end = end
 

--- a/rts/sprites/route.py
+++ b/rts/sprites/route.py
@@ -28,7 +28,7 @@ class Route:
             self.end.rect.center,
             width=self.width,
         )
-        
+
         # Each soldier will have the other tower as a target
         soldiers = EntityController().entities(Soldier)
         for entity in soldiers:
@@ -42,7 +42,7 @@ class Route:
         """
         Do things if the position given is over the route.
         This method has side effects inside, we should fix it.
-        
+
         :param pos: Position of the object to check over the route
         :param surf: Screen surface where to draw new objects
         :return: True if is over, false otherwise

--- a/rts/sprites/ruler.py
+++ b/rts/sprites/ruler.py
@@ -74,7 +74,6 @@ class Ruler(GameEntity):
             # Check if the soldier hit is owned by the ruler or not.
             if s.ownership.ownership != self:
                 i.die()
-                soldiers.remove(i)
 
     # Moves the instance depending on the keys pressed
     def update_position(self) -> None:

--- a/rts/sprites/soldier.py
+++ b/rts/sprites/soldier.py
@@ -20,10 +20,6 @@ class Soldier(GameEntity):
     target: Tower
 
     selected: bool
-    """
-    Gets or sets if the soldier is selected or not.
-    You can select a soldier by moving mouse over it or over the tower owner.
-    """
 
     # Constructor
     def __init__(
@@ -95,11 +91,9 @@ class Soldier(GameEntity):
                 # If enemy, everyone has to die
                 if sprite.ownership.ownership != self.ownership.ownership:
                     # Kill the enemy.
-                    sprite.kill()
                     sprite.die()
 
                     # Kill the sprite itself.
-                    self.kill()
                     self.die()
                     # Break to remove only one soldier each soldier collision.
                     break
@@ -109,7 +103,6 @@ class Soldier(GameEntity):
                 # Soldiers with a target must die only when colliding with the target tower
                 if self.target == sprite:
                     print("E' il mio target!!!")
-                    self.kill()
                     self.die()
                     sprite.die_random_soldier(self)
                     break
@@ -117,7 +110,6 @@ class Soldier(GameEntity):
                 # Soldiers without a target must die when they collide with an enemy tower
                 if sprite.ownership != self.ownership.ownership:
                     print(f"Non e' il mio target {self.target} e {sprite}")
-                    self.kill()
                     self.die()
                     break
 

--- a/rts/sprites/tower.py
+++ b/rts/sprites/tower.py
@@ -77,6 +77,10 @@ class Tower(GameEntity):
         self.soldier_gen_ratio = soldier_gen_ratio
         self.tower_tooltip: pygame_gui.elements.UITooltip = None
 
+        from rts.sprites.route import Route
+
+        self.exit_route: Route = None
+
     # Updates the state of the instance
     def update(self, delta: int) -> None:
         """Update tower and her soldiers.

--- a/tests/controllers/test_entity_controller.py
+++ b/tests/controllers/test_entity_controller.py
@@ -2,7 +2,10 @@ import pytest
 
 from rts.controllers.entity_controller import EntityController
 from rts.models.game_entity import GameEntity
+from rts.sprites.ruler import Ruler
 from rts.sprites.soldier import Soldier
+from rts.sprites.tower import Tower
+
 
 @pytest.fixture
 def sample_entity_controller():
@@ -11,32 +14,63 @@ def sample_entity_controller():
     c.reset()
     del c
 
+
 @pytest.fixture
 def sample_soldier():
     return Soldier(GameEntity(0, 0, [0, 0, 0], [0, 0]), [0, 0], 0, None, 0)
+
 
 def test_empty_dict(sample_entity_controller: EntityController):
     assert len(sample_entity_controller.game_entities) == 0
     assert len(sample_entity_controller.entity_dict) == 0
 
-def test_call_entities_create_new_group(sample_entity_controller: EntityController):
+
+def test_call_entities_create_new_group(
+    sample_entity_controller: EntityController,
+):
     assert len(sample_entity_controller.entities(Soldier).sprites()) == 0
     assert len(sample_entity_controller.entity_dict) == 1
     assert len(sample_entity_controller.game_entities) == 0
+
 
 def test_has_empty_dict(sample_entity_controller: EntityController):
     assert len(sample_entity_controller.entity_dict) == 0
     assert not sample_entity_controller.has(Soldier)
 
-def test_has_e_empty_dict(sample_entity_controller: EntityController, sample_soldier: Soldier):
+
+def test_has_e_empty_dict(
+    sample_entity_controller: EntityController, sample_soldier: Soldier
+):
     assert not sample_entity_controller.has_e(sample_soldier)
 
-def test_add_one_entity(sample_entity_controller: EntityController, sample_soldier: Soldier):
+
+def test_add_one_entity(
+    sample_entity_controller: EntityController, sample_soldier: Soldier
+):
     sample_entity_controller.register_entity(sample_soldier)
     assert len(sample_entity_controller.entity_dict) == 1
     assert len(sample_entity_controller.entities(Soldier).sprites()) == 1
 
-def test_one_entity_to_check(sample_entity_controller: EntityController, sample_soldier: Soldier):
+
+def test_one_entity_to_check(
+    sample_entity_controller: EntityController, sample_soldier: Soldier
+):
     sample_entity_controller.register_entity(sample_soldier)
     assert sample_entity_controller.has(Soldier)
     assert sample_entity_controller.has_e(sample_soldier)
+
+def test_sprite_instances(sample_entity_controller: EntityController):
+    r1 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
+    t1 = Tower(
+        GameEntity(0, 0, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 0.1
+    )
+    s1 = Soldier(GameEntity(0, 1, [0, 0, 0], [1, 1]), [0, 0], 0, t1, 0)
+    sample_entity_controller.register_entity(r1)
+    sample_entity_controller.register_entity(t1)
+    sample_entity_controller.register_entity(s1)
+    e1 = sample_entity_controller.entities(Ruler).sprites().pop()
+    assert isinstance(e1, Ruler)
+    e2 = sample_entity_controller.entities(Tower).sprites().pop()
+    assert isinstance(e2, Tower)
+    e3 = sample_entity_controller.entities(Soldier).sprites().pop()
+    assert isinstance(e3, Soldier)

--- a/tests/controllers/test_entity_controller.py
+++ b/tests/controllers/test_entity_controller.py
@@ -59,6 +59,7 @@ def test_one_entity_to_check(
     assert sample_entity_controller.has(Soldier)
     assert sample_entity_controller.has_e(sample_soldier)
 
+
 def test_sprite_instances(sample_entity_controller: EntityController):
     r1 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
     t1 = Tower(

--- a/tests/controllers/test_time_controller.py
+++ b/tests/controllers/test_time_controller.py
@@ -13,9 +13,9 @@ def sample_time_controller(mock: MagicMock):
 
 
 def test_delta(sample_time_controller: TimeController):
-    assert sample_time_controller.update(1000) == 0
+    assert sample_time_controller.update(1000)
 
 
 def test_double_delta(sample_time_controller: TimeController):
-    assert sample_time_controller.update(500) == 0.5
-    assert sample_time_controller.update(500) == 0
+    assert not sample_time_controller.update(500)
+    assert sample_time_controller.update(500)

--- a/tests/sprites/test_routes.py
+++ b/tests/sprites/test_routes.py
@@ -6,14 +6,18 @@ from rts.sprites.route import Route
 from rts.sprites.ruler import Ruler
 from rts.sprites.tower import Tower
 
+
 @pytest.fixture
 def make_tower():
     r1 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
-    
-    def _make_tower(x = 0, y = 0):
-        return Tower(GameEntity(x, y, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 1)
-    
+
+    def _make_tower(x=0, y=0):
+        return Tower(
+            GameEntity(x, y, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 1
+        )
+
     return _make_tower
+
 
 @pytest.fixture
 def sample_route(make_tower) -> Route:
@@ -21,19 +25,23 @@ def sample_route(make_tower) -> Route:
     t2: Tower = make_tower(1, 1)
     return Route(t1, t2)
 
+
 def test_over_without_update(sample_route: Route):
     mouse_pos = [0, 0]
     assert not sample_route.over(mouse_pos)
+
 
 def test_over_with_update(sample_route: Route):
     mouse_pos = [0, 0]
     sample_route.update(0, Surface([2, 2]))
     assert sample_route.over(mouse_pos)
 
+
 def test_not_over(sample_route: Route):
     mouse_pos = [2, 2]
     sample_route.update(0, Surface([2, 2]))
     assert not sample_route.over(mouse_pos)
+
 
 def test_width_not_over(sample_route: Route):
     mouse_pos = [2, 2]
@@ -41,6 +49,7 @@ def test_width_not_over(sample_route: Route):
     sample_route.over(mouse_pos)
     assert sample_route.width == 2
     assert sample_route.color == TEXT_COLOR
+
 
 def test_width_over(sample_route: Route):
     mouse_pos = [1, 1]

--- a/tests/sprites/test_routes.py
+++ b/tests/sprites/test_routes.py
@@ -1,9 +1,11 @@
 from pygame import Surface
 import pytest
 from rts.config import TEXT_COLOR
+from rts.controllers.entity_controller import EntityController
 from rts.models.game_entity import GameEntity
 from rts.sprites.route import Route
 from rts.sprites.ruler import Ruler
+from rts.sprites.soldier import Soldier
 from rts.sprites.tower import Tower
 
 
@@ -57,3 +59,23 @@ def test_width_over(sample_route: Route):
     sample_route.over(mouse_pos)
     assert sample_route.width == 4
     assert sample_route.color == "green"
+
+
+def test_route_update(sample_route: Route):
+    c = EntityController()
+    c.reset()
+
+    s1 = Soldier(
+        GameEntity(0, 0, [0, 0, 0], [1, 1]), [0, 0], 0, sample_route.start, 0
+    )
+    s2 = Soldier(
+        GameEntity(0, 1, [0, 0, 0], [1, 1]), [0, 0], 0, sample_route.end, 0
+    )
+
+    c.register_entity(s1)
+    c.register_entity(s2)
+
+    sample_route.update(delta=0, screen=Surface([0, 0]))
+
+    assert s1.target == sample_route.end
+    assert s2.target == sample_route.start

--- a/tests/sprites/test_soldiers.py
+++ b/tests/sprites/test_soldiers.py
@@ -9,7 +9,13 @@ from rts.sprites.tower import Tower
 
 @pytest.fixture
 def sample_soldier() -> Soldier:
-    return Soldier(GameEntity(0, 0, [0, 0, 0], [0, 0]), [0, 0], 0, None, 0)
+    return Soldier(
+        GameEntity(0, 0, [0, 0, 0], [0, 0]),
+        [0, 0],
+        0,
+        GameEntity(0, 0, [0, 0, 0], [0, 0]),
+        0,
+    )
 
 
 @pytest.fixture
@@ -17,6 +23,9 @@ def delta() -> int:
     return 1
 
 
+@pytest.mark.skip(
+    reason="In this update, this was removed. In a future release, it will be readded only for stationary soldiers."
+)
 def test_simple_soldier_increment_initiative(
     sample_soldier: Soldier, delta: int
 ):
@@ -28,7 +37,13 @@ def test_simple_soldier_increment_initiative(
     )
 
 
+@pytest.mark.skip(
+    reason="In this update, this was removed. In a future release, it will be readded only for stationary soldiers."
+)
 def test_simple_soldier_reset_initiative(sample_soldier: Soldier, delta: int):
+    """
+    In this test we ensure that initiative will be decremented reaching the limit of 1.
+    """
     for i in range(0, 100):
         sample_soldier.update(delta=delta)
     assert abs(sample_soldier.initiative - 0.11) < 1e-16
@@ -68,7 +83,9 @@ def test_collision_between_soldiers():
     e = EntityController()
     e.register_entity(s1)
     e.register_entity(s2)
-    s1.update(1)
-    print(e.entity_dict[Soldier])
+
+    # With 0 delta entities don't move, so the two soldiers collide and have to be removed.
+    e.game_entities.update(delta=0)
+
     assert s1 not in e.entity_dict[Soldier]
     assert s2 not in e.entity_dict[Soldier]

--- a/tests/sprites/test_soldiers.py
+++ b/tests/sprites/test_soldiers.py
@@ -33,11 +33,16 @@ def test_simple_soldier_reset_initiative(sample_soldier: Soldier, delta: int):
         sample_soldier.update(delta=delta)
     assert abs(sample_soldier.initiative - 0.11) < 1e-16
 
+
 def test_collision_between_soldiers():
     r1 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
     r2 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
-    t1 = Tower(GameEntity(0, 0, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 0.1)
-    t2 = Tower(GameEntity(0, 0, [0, 0, 0], [0, 0]), r2, 1, [0, 0, 0], [0, 0], 0.1)
+    t1 = Tower(
+        GameEntity(0, 0, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 0.1
+    )
+    t2 = Tower(
+        GameEntity(0, 0, [0, 0, 0], [0, 0]), r2, 1, [0, 0, 0], [0, 0], 0.1
+    )
     s1 = Soldier(GameEntity(0, 0, [0, 0, 0], [1, 1]), [0, 0], 0, t1, 0)
     s2 = Soldier(GameEntity(0, 1, [0, 0, 0], [1, 1]), [0, 0], 0, t2, 0)
     e = EntityController()
@@ -47,12 +52,17 @@ def test_collision_between_soldiers():
     print(e.entity_dict[Soldier])
     assert s1 in e.entity_dict[Soldier]
     assert s2 in e.entity_dict[Soldier]
-    
+
+
 def test_collision_between_soldiers():
     r1 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
     r2 = Ruler(GameEntity(0, 0, [0, 0, 0], [0, 0]), 1)
-    t1 = Tower(GameEntity(0, 0, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 0.1)
-    t2 = Tower(GameEntity(0, 0, [0, 0, 0], [0, 0]), r2, 1, [0, 0, 0], [0, 0], 0.1)
+    t1 = Tower(
+        GameEntity(0, 0, [0, 0, 0], [0, 0]), r1, 1, [0, 0, 0], [0, 0], 0.1
+    )
+    t2 = Tower(
+        GameEntity(0, 0, [0, 0, 0], [0, 0]), r2, 1, [0, 0, 0], [0, 0], 0.1
+    )
     s1 = Soldier(GameEntity(0, 1, [0, 0, 0], [1, 1]), [0, 0], 0, t1, 0)
     s2 = Soldier(GameEntity(0, 1, [0, 0, 0], [1, 1]), [0, 0], 0, t2, 0)
     e = EntityController()

--- a/tests/sprites/test_tower_soldier_collisions.py
+++ b/tests/sprites/test_tower_soldier_collisions.py
@@ -1,0 +1,58 @@
+from typing import Callable
+from unittest.mock import MagicMock, patch
+import pytest
+from rts.controllers.entity_controller import EntityController
+from rts.models.game_entity import GameEntity
+
+from rts.sprites.ruler import Ruler
+from rts.sprites.soldier import Soldier
+from rts.sprites.tower import Tower
+
+color = [0, 0, 0]
+size = [1, 1]
+
+@pytest.fixture
+def ruler() -> Ruler:
+    def _ruler():
+        return Ruler(GameEntity(1, 1, color, size), 1)
+    
+    return _ruler
+
+@pytest.fixture
+def tower(ruler: Ruler) -> Callable[[float, float, Ruler], Tower]:
+    default_ruler = ruler()
+    
+    def _tower(x: float, y: float, owner: Ruler):
+        owned_by = owner if owner else default_ruler
+        return Tower(GameEntity(x, y, color, size), owned_by, 1, color, size, 1)
+    
+    return _tower
+
+@pytest.fixture
+def soldier():
+    def _soldier(x: float, y: float, tower: Tower):
+        return Soldier(GameEntity(x, y, color, size), [x, y], 0, tower, 1)
+
+    return _soldier
+
+@patch("rts.sprites.tower.Tower._update_soldiers_label")
+@patch("rts.sprites.tower.Tower._update_level_label")
+def test_soldier_tower_collision(mock: MagicMock,mock2: MagicMock, tower: Callable[[float, float, Ruler], Tower], soldier, ruler):
+    r1 = ruler()
+    r2 = ruler()
+    t1: Tower = tower(0, 0, r1)
+    t2: Tower = tower(1, 1, r2)
+    s1: Soldier = soldier(1, 1, t1)
+    s1.target = t2
+    e = EntityController()
+    e.reset()
+    e.register_entity(t1)
+    e.register_entity(t2)
+    e.register_entity(s1)
+    
+    # Entities doesn't move, collision appen between s1 and t2.
+    assert s1.rect.colliderect(t2.rect)
+    assert not s1.rect.colliderect(t1.rect)
+    e.game_entities.update(delta=0)
+    assert s1 not in e.entities(Soldier)
+    assert not s1.alive()


### PR DESCRIPTION
With this pull request now routes are dismissed when a tower is conquered.

What is missing is that soldiers, without a target, will be "teleported" back to their tower. What we should do is to decide if they have to return back to their tower owner or to become owned by the conquered tower (I prefer this). This will be discussed in an issue in the future I think.